### PR TITLE
docs: add Create Awesome Node App banner and NaNLABS attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 <h1>React Boilerplate</h1>
 
 </div>
+
+<div align="center">
+  <a href="https://www.npmjs.com/package/create-awesome-node-app">
+    <img src="https://img.shields.io/badge/Generated%20with-Create%20Awesome%20Node%20App-6B46C1?style=for-the-badge&logo=npm" alt="Generated with Create Awesome Node App">
+  </a>
+  <a href="https://github.com/Create-Node-App">
+    <img src="https://img.shields.io/badge/Powered%20by-Create%E2%80%A2Node%E2%80%A2App-223344?style=for-the-badge&logo=github" alt="Powered by Create-Node-App">
+  </a>
+</div>
+
 <div align="center">
 
 [![Main Validation](https://github.com/nanlabs/react-boilerplate/actions/workflows/ci.yml/badge.svg)](https://github.com/nanlabs/react-boilerplate/actions/workflows/ci.yml)
@@ -12,6 +22,12 @@
 [licenseurl]: https://github.com/nanlabs/react-boilerplate/master/LICENSE
 
 </div>
+
+<div align="center">
+  <p><strong>NaNLABS</strong> uses and actively contributes to the maintenance of <a href="https://www.npmjs.com/package/create-awesome-node-app">Create Awesome Node App</a> — an open-source CLI tool for scaffolding Node.js projects.</p>
+</div>
+
+---
 
 This project was generated using [create-awesome-node-app](https://www.npmjs.com/package/create-awesome-node-app). **DON'T USE THIS TEMPLATE AS IT!** Generate yours using the command and following the options in the interactive menu. Check the docs for more information!
 


### PR DESCRIPTION
## Summary

Adds prominent **Create Awesome Node App** banner with links to the NPM package and GitHub organization, plus a notice that NaNLABS uses and actively contributes to the tool.

## Changes

- Added styled badge banners linking to NPM package and Create-Node-App GitHub org
- Added NaNLABS attribution paragraph